### PR TITLE
Switching to exclude mode of find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(name="ustudio-hmac-tornado",
       version="0.1.1",
       description="Simple HMAC Client/Server authentication for Tornado",
       url="https://github.com/ustudio/ustudio-hmac-tornado",
-      packages=find_packages(include=["hmacauth"]),
+      packages=find_packages(exclude=["tests", "dist"]),
       install_requires=install_requires)


### PR DESCRIPTION
Because include doesn't allow for automatic nested packages.

@ustudio/dev Please review