### PR TITLE
Add support for normalized query parameters in the signing algorithm.

### DIFF
--- a/hmacauth/client/authenticated_request.py
+++ b/hmacauth/client/authenticated_request.py
@@ -17,16 +17,15 @@ def authenticated_request(*args, **kwargs):
         raise TypeError("Missing argument: 'url'")
 
     parsed_url = urlparse(url)
-    if len(parsed_url.query) > 0:
-        raise NotImplementedError("HMAC Authorized requests with query strings not yet supported")
 
     path = parsed_url.path
+    query = parsed_url.query
 
     body = kwargs.get("body", "")
     if isinstance(body, str):
         body = body.encode("utf-8")
 
-    digest = generate_digest(hmac_secret, kwargs.get("method", "GET"), path, body)
+    digest = generate_digest(hmac_secret, kwargs.get("method", "GET"), path, query, body)
 
     headers = kwargs.get("headers", {})
     headers["Authorization"] = "USTUDIO-HMAC-V2 {} {}".format(hmac_key, digest)

--- a/hmacauth/digest.py
+++ b/hmacauth/digest.py
@@ -1,10 +1,19 @@
 import hmac
 import hashlib
+import urllib.parse
 
 
-def generate_digest(secret, method, path, body):
+def generate_digest(secret, method, path, query, body):
+    parsed_query = urllib.parse.parse_qs(query, keep_blank_values=True)
+
+    canonical_query = []
+
+    for key in sorted(parsed_query.keys()):
+        for value in sorted(parsed_query[key]):
+            canonical_query.append("=".join((key, urllib.parse.quote(value))))
+
     return hmac.new(
         secret.encode("utf-8"),
-        "\n".join((method, path, "", "")).encode("utf-8") +
+        "\n".join((method, path, "&".join(canonical_query), "")).encode("utf-8") +
         body,
         hashlib.sha256).hexdigest()

--- a/hmacauth/server/hmac_authorizer.py
+++ b/hmacauth/server/hmac_authorizer.py
@@ -10,10 +10,6 @@ from hmacauth.digest import generate_digest
 def hmac_authorized(method):
     @functools.wraps(method)
     def hmac_authorized_wrapper(handler, *args, **kwargs):
-        if len(handler.request.query) > 0:
-            logging.warning("Unsupported query arguments on HMAC authorized request")
-            raise HTTPError(400)
-
         authorization = handler.request.headers.get("Authorization", "").split(" ")
         if len(authorization) != 3:
             logging.info("Invalid Authorization header {}".format(authorization))
@@ -30,7 +26,8 @@ def hmac_authorized(method):
             raise HTTPError(401)
 
         expected_digest = generate_digest(
-            secret, handler.request.method, handler.request.path, handler.request.body)
+            secret, handler.request.method, handler.request.path, handler.request.query,
+            handler.request.body)
 
         if not hmac.compare_digest(expected_digest, provided_digest):
             logging.info("Invalid HMAC digest {}".format(provided_digest))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
 ]
 
 setup(name="ustudio-hmac-tornado",
-      version="0.1.3",
+      version="0.2.0",
       description="Simple HMAC Client/Server authentication for Tornado",
       url="https://github.com/ustudio/ustudio-hmac-tornado",
       packages=find_packages(exclude=["tests", "dist"]),

--- a/tests/client/test_authenticated_request.py
+++ b/tests/client/test_authenticated_request.py
@@ -90,9 +90,10 @@ class TestAuthenticatedRequest(BaseHMACTestCase):
                 hmac_secret="secret"))
 
     @gen_test
-    async def test_raises_exception_when_query_arguments_present(self):
-        with self.assertRaises(NotImplementedError):
-            await self.http_client.fetch(authenticated_request(
-                url=self.get_url("/authorized/argument?query=not&yet=supported"),
-                hmac_key="correct-key",
-                hmac_secret="secret"))
+    async def test_normalizes_and_signs_query_arguments(self):
+        response = await self.http_client.fetch(authenticated_request(
+            url=self.get_url("/authorized/argument?bar=value%202&Foo=value%3f1&blank"),
+            hmac_key="correct-key",
+            hmac_secret="secret"))
+
+        self.assertEqual(200, response.code)


### PR DESCRIPTION
Does what it says. We normalize following a similar, but not identical, algorithm to AWS v4. We explicitly support duplicated query parameters, though, by sorting the duplicated values.

@ustudio/dev Please review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/ustudio-hmac-tornado/5)
<!-- Reviewable:end -->
